### PR TITLE
Add response parsing and typifications to http_client

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,20 +3,21 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.0.0-rc4",
+  "version": "1.0.0-rc5",
   "description": "Tools for the HTTP protocol",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
   "contributors": [
     "Sebastian Meier <sebastian.meier@5minds.de>",
+    "Christian Werner <christian.werner@5minds.de>",
     "Patrick Pötschke <patrick.poetschke@quantusflow.com>",
     "Simon Reymann <simon.reymann@quantusflow.com>"
   ],
   "license": "MIT",
   "dependencies": {
-    "@essential-projects/http_contracts": "^1.0.0-rc3",
+    "@essential-projects/http_contracts": "^1.0.0-rc5",
     "bluebird": "^3.4.6",
-    "popsicle": "^9.1.0"
+    "popsicle": "^9.2.0"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "^1.0.0-rc3",

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -5,9 +5,13 @@ export class HttpClient implements IHttpClient {
 
   public config: any = undefined;
 
+  private httpSuccessResponseCode: number = 200;
+  private httpSuccessNoContentResponseCode: number = 204;
+  private httpRedirectResponseCode: number = 300;
+
   protected buildRequestOptions(method: string, url: string, options?: IRequestOptions): IRequestOptions {
 
-    const baseUrl = this.config && this.config.url ? `${this.config.url}/` : '';
+    const baseUrl: string = this.config && this.config.url ? `${this.config.url}/` : '';
 
     const requestOptions: any = {
       method: method,
@@ -28,13 +32,13 @@ export class HttpClient implements IHttpClient {
     return requestOptions;
   }
 
-  private _deleteEmptyOptions(options: any) {
+  private _deleteEmptyOptions(options: any): void {
 
-    const propertyKeys = Object.keys(options);
+    const propertyKeys: Array<string> = Object.keys(options);
 
-    propertyKeys.forEach((attributeKey) => {
+    propertyKeys.forEach((attributeKey: string) => {
 
-      const value = options[attributeKey];
+      const value: any = options[attributeKey];
       if (value === undefined || value === null) {
         delete options[attributeKey];
       }
@@ -46,16 +50,16 @@ export class HttpClient implements IHttpClient {
 
   public async get<T>(url: string, options?: IRequestOptions): Promise<IResponse<T>> {
 
-    const requestOptions = this.buildRequestOptions('GET', url, options);
+    const requestOptions: IRequestOptions = this.buildRequestOptions('GET', url, options);
 
-    const result = await popsicle.request(requestOptions);
+    const result: any = await popsicle.request(requestOptions);
 
-    if (result.status < 200 || result.status >= 300) {
+    if (result.status < this.httpSuccessResponseCode || result.status >= this.httpRedirectResponseCode) {
       throw new Error(result.body);
     }
 
-    const response = {
-      result: result.body,
+    const response: IResponse<T> = {
+      result: this.parsePopsicleResponse(result.body),
       status: result.status,
     };
 
@@ -67,14 +71,14 @@ export class HttpClient implements IHttpClient {
 
     requestOptions.body = data;
 
-    const result = await popsicle.request(requestOptions);
+    const result: any = await popsicle.request(requestOptions);
 
-    if (result.status < 200 || result.status >= 300) {
+    if (result.status < this.httpSuccessResponseCode || result.status >= this.httpRedirectResponseCode) {
       throw new Error(result.body);
     }
 
     const response: IResponse<T> = {
-      result: result.body,
+      result: this.parsePopsicleResponse(result.body),
       status: result.status,
     };
 
@@ -88,14 +92,14 @@ export class HttpClient implements IHttpClient {
 
     requestOptions.body = data;
 
-    const result = await popsicle.request(requestOptions);
+    const result: any = await popsicle.request(requestOptions);
 
-    if (result.status < 200 || result.status >= 300) {
+    if (result.status < this.httpSuccessResponseCode || result.status >= this.httpRedirectResponseCode) {
       throw new Error(result.body);
     }
 
-    const response = {
-      result: result.body,
+    const response: IResponse<T> = {
+      result: this.parsePopsicleResponse(result.body),
       status: result.status,
     };
 
@@ -104,19 +108,30 @@ export class HttpClient implements IHttpClient {
 
   public async delete<T>(url: string, options?: IRequestOptions): Promise<IResponse<T>> {
 
-    const requestOptions = this.buildRequestOptions('DELETE', url, options);
+    const requestOptions: IRequestOptions = this.buildRequestOptions('DELETE', url, options);
 
-    const result = await popsicle.request(requestOptions);
+    const result: any = await popsicle.request(requestOptions);
 
-    if (result.status !== 204 && result.status !== 200) {
+    if (result.status !== this.httpSuccessNoContentResponseCode && result.status !== this.httpSuccessResponseCode) {
       throw new Error(result.body);
     }
 
-    const response = {
-      result: result.body,
+    const response: IResponse<T> = {
+      result: this.parsePopsicleResponse(result.body),
       status: result.status,
     };
 
     return response;
+  }
+
+  private parsePopsicleResponse(result: any): any {
+    // NOTE: For whatever reason, every response.body received by popsicle is a string,
+    // even in a response header "Content-Type application/json" is set.
+    // To get around this, we have to cast the result manually.
+    if (typeof result !== 'string') {
+      return result;
+    }
+
+    return JSON.parse(result);
   }
 }


### PR DESCRIPTION
## What did you change?

- Add missing types to method signatures and variables
- Add response body parsing for JSON responses, since popsicle doesn't seem to be doing that on its own. This was discovered during the implementation of the consumer_api_client
- Bump versions

## How can others test the changes?

- Create an app that uses this version of the httpClient and paste the following:
```
  public async getProcessModels(): Promise<T> {
    const httpResponse: IResponse<T> = await this.httpClient.get<T>('route');

    return httpResponse.result;
  }
```
- Replace `route` with any http route you are sure returns a JSON response and `T` with whatever type suits your use case
- Call the function
- See that the response is a JSON object

**HINT**:
You can also verify this, by checking out the `feature/consumer_api` in the `process_engine_meta` repository and running the integration tests

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
