### PR TITLE
Fix handling of empty response bodies

### DIFF
--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -126,12 +126,12 @@ export class HttpClient implements IHttpClient {
 
   private parsePopsicleResponse(result: any): any {
     // NOTE: For whatever reason, every response.body received by popsicle is a string,
-    // even in a response header "Content-Type application/json" is set.
+    // even in a response header "Content-Type application/json" is set, or if the response body does not exist.
     // To get around this, we have to cast the result manually.
-    if (typeof result !== 'string') {
+    try {
+      return JSON.parse(result);
+    } catch (error) {
       return result;
     }
-
-    return JSON.parse(result);
   }
 }


### PR DESCRIPTION
## What did you change?

Apparently, popsicle **always** returns empty strings for response bodies, even if the actual HTTP response didn't even contain a body. 

To get around this problem and to avoid further issues with response body parsing, the `parsePopsicleResponse` now always tries to parse the given response into a JSON object within a try/catch segment.
If the cast fails, the original response object is returned. 

## How can others test the changes?

- Create an app that uses the HTTP client to perform a request against a POST or PUT route you are sure to return an empty response body.
- Notice that the whole thing doesn't crash.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
