### PR TITLE
Refactor response handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Tools for the HTTP protocol",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -15,6 +15,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@essential-projects/errors_ts": "^1.1.0",
     "@essential-projects/http_contracts": "^1.0.0",
     "bluebird": "^3.4.6",
     "popsicle": "^9.2.0"

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -32,7 +32,6 @@ export class HttpClient implements IHttpClient {
     const parsedResponse: IResponse<T> = this._evaluateResponse<T>(response);
 
     return parsedResponse;
-
   }
 
   public async put<T>(url: string, data: T, options?: IRequestOptions): Promise<IResponse<T>> {
@@ -118,9 +117,17 @@ export class HttpClient implements IHttpClient {
 
   private _createAndThrowEssentialProjectsError(response: any): void {
     const responseStatusCode: number = response.status;
-    const essentialProjectsErrorName: string = EssentialProjectErrors.ErrorCodes[responseStatusCode];
+    const errorName: string = EssentialProjectErrors.ErrorCodes[responseStatusCode];
 
-    throw new EssentialProjectErrors[essentialProjectsErrorName](response.body);
+    if (!this._isEssentialProjectsError(errorName)) {
+      throw new Error(response.body);
+    }
+
+    throw new EssentialProjectErrors[errorName](response.body);
+  }
+
+  private _isEssentialProjectsError(errorName: string): boolean {
+    return errorName in EssentialProjectErrors;
   }
 
   private _parseResponseBody(result: any): any {


### PR DESCRIPTION
## What did you change?

- Move entire response handling to '_evaluateResponse' function for all request types
- Split handling of responses into smaller functions, each handling a specific step
- When a response contains an error, it is parsed into an error type from the @essential-projects/errors_ts project

## How can others test the changes?

Use the HTTP client in an existing application and see that the Http Client now throws errors from the errors_ts package.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
