### PR TITLE
💄 Cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "Tools for the HTTP protocol",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,10 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/http_contracts": "^2.4.0",
-    "bluebird": "~3.5.2",
-    "popsicle": "~9.2.0"
+    "popsicle": "^10.0.0"
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@types/express": "^4.16.1",
     "@types/node": "^12.11.7",
     "@types/socket.io": "^2.1.0",
     "eslint": "^6.6.0",

--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import * as EssentialProjectErrors from '@essential-projects/errors_ts';
 import {IHttpClient, IRequestOptions, IResponse} from '@essential-projects/http_contracts';
 import * as popsicle from 'popsicle';


### PR DESCRIPTION
## Changes

1. Remove unnecessary usages of `any`
2. remove eslint rule overrides
3. Refine error parsing to allow for plain string error messages
4. Upgrade popsicle to v10.
    - This is the last version that uses the current semantic. 
    - v11 and v12 were completely overhauled and use a completely different mechanism, which will take time to implement here

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/491

PR: #8

## How to test the changes

- Run requests that will return plain string errors as body
- See that the errors are interpreted correctly